### PR TITLE
Remove PyPI instructions

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -123,72 +123,18 @@ bump-my-version patch  # bumps from e.g. 0.3.2 to 0.3.3
 
 ## Making a release
 
-This section describes how to make a release in 3 parts:
+This section describes how to make a release in 2 parts:
 
 1. preparation
-1. making a release on PyPI
 1. making a release on GitHub
 
-### (1/3) Preparation
+### (1/2) Preparation
 
 1. Update the <CHANGELOG.md> (don't forget to update links at bottom of page)
 2. Verify that the information in [`CITATION.cff`](CITATION.cff) is correct.
 3. Make sure the [version has been updated](#versioning).
 4. Run the unit tests with `pytest -v`
 
-### (2/3) PyPI
+### (2/2) GitHub
 
-In a new terminal:
-
-```shell
-# OPTIONAL: prepare a new directory with fresh git clone to ensure the release
-# has the state of origin/main branch
-cd $(mktemp -d tesops_electricity.XXXXXX)
-git clone git@github.com:ESI-FAR/tesops-electricity_nilm .
-
-# make sure to have a recent version of pip and the publishing dependencies
-python -m pip install --upgrade pip
-python -m pip install .[publishing]
-
-# create the source distribution and the wheel
-python -m build
-
-# upload to test pypi instance (requires credentials)
-python -m twine upload --repository testpypi dist/*
-```
-
-Visit
-[https://test.pypi.org/project/tesops_electricity](https://test.pypi.org/project/tesops_electricity)
-and verify that your package was uploaded successfully. Keep the terminal open, we'll need it later.
-
-In a new terminal, without an activated virtual environment or an env directory:
-
-```shell
-cd $(mktemp -d tesops_electricity-test.XXXXXX)
-
-# prepare a clean virtual environment and activate it
-python -m venv env
-source env/bin/activate
-
-# make sure to have a recent version of pip and setuptools
-python -m pip install --upgrade pip
-
-# install from test pypi instance:
-python -m pip -v install --no-cache-dir \
---index-url https://test.pypi.org/simple/ \
---extra-index-url https://pypi.org/simple electricity
-```
-
-Check that the package works as it should when installed from pypitest.
-
-Then upload to pypi.org with:
-
-```shell
-# Back to the first terminal,
-# FINAL STEP: upload to PyPI (requires credentials)
-python -m twine upload dist/*
-```
-
-### (3/3) GitHub
-
-Don't forget to also make a [release on GitHub](https://github.com/ESI-FAR/tesops-electricity_nilm/releases/new). If your repository uses the GitHub-Zenodo integration this will also trigger Zenodo into making a snapshot of your repository and sticking a DOI on it.
+Make a [release on GitHub](https://github.com/ESI-FAR/tesops-electricity_nilm/releases/new). If your repository uses the GitHub-Zenodo integration this will also trigger Zenodo into making a snapshot of your repository and sticking a DOI on it.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pytorch implementation of ELECTRIcity: An efficient Transformer for Non-Intrusiv
 
 ## Data
 
-The csv datasets could be downloaded here: [REDD](http://redd.csail.mit.edu/), [UK-DALE](https://jack-kelly.com/data/) and [Refit](https://pureportal.strath.ac.uk/en/datasets/refit-electrical-load-measurements-cleaned)
+The csv datasets could be downloaded here: ~REDD~[^1], [UK-DALE](https://jack-kelly.com/data/) and [Refit](https://pureportal.strath.ac.uk/en/datasets/refit-electrical-load-measurements-cleaned)
 
 For Refit, we used a slightly different folder structure. We have created .txt files with columns labels that are required during data processing. Please place the .csv files in the Data Folder for the code to work.
 
@@ -98,3 +98,7 @@ DOI = {10.3390/s22082926}
 ## Acknowledgement
 
 We used [BERT4NILM](https://github.com/Yueeeeeeee/BERT4NILM) by Yue et. al. as template for our code. We would like to thank the authors for their valuable work that has inspired ours!
+
+<!-- markdown-link-check-disable -->
+[^1]: Original download site ~http://redd.csail.mit.edu/~ is no longer online
+<!-- markdown-link-check-enable -->


### PR DESCRIPTION
Fixes #37 

Removes release to PyPI instructions. 
Since this removes one of the two broken links, I've also removed the other broken link (REDD Dataset) from the regular README, so now the markdown checker action should pass.