### PR TITLE
Fix coverage

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install .[dev]
       - name: Run unit tests with coverage
-        run: python -m pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml tests/
+        run: python -m pytest --cov=electricity --cov-report term --cov-report xml --junitxml=xunit-result.xml tests/
       - name: Correct coverage paths
         run: sed -i "s+$PWD/++g" coverage.xml
       - name: SonarCloud Scan


### PR DESCRIPTION
Coverage for Sonarcloud was being reported at 0%. By explicitly specifying the package to cover, i.e., `pytest --cov=electricity`, that is fixed.

Related issue: #34 