### PR TITLE
Fix bool parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ Repository = "https://github.com/ESI-FAR/tesops-electricity_nilm"
 Issues = "https://github.com/ESI-FAR/tesops-electricity_nilm/issues"
 Changelog = "https://github.com/ESI-FAR/tesops-electricity_nilm/CHANGELOG.md"
 
+[project.scripts]
+electricity = "electricity.electricity:train"
+
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 

--- a/src/electricity/electricity.py
+++ b/src/electricity/electricity.py
@@ -11,9 +11,10 @@ from .parsers import RefitParser
 from .parsers import UKDaleParser
 from .Trainer import Trainer
 
-torch.set_default_tensor_type(torch.DoubleTensor)
 
-if __name__ == "__main__":
+def train():
+    torch.set_default_tensor_type(torch.DoubleTensor)
+
     args = get_args()
     setup_seed(args.seed)
 
@@ -95,3 +96,7 @@ if __name__ == "__main__":
 
     fname = trainer.export_root / "results.pkl"
     pkl.dump(results, open(fname, "wb"))
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
Replace `bool` type with a custom `str2bool` function that implements how bools _should_ have worked in `argparse`.

Closes #61 